### PR TITLE
Potential fix for code scanning alert no. 10: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/phumlanidev/productservice/config/SecurityConfig.java
+++ b/src/main/java/com/phumlanidev/productservice/config/SecurityConfig.java
@@ -27,7 +27,9 @@ public class SecurityConfig {
    */
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
+    http.csrf(csrf -> csrf
+            .ignoringRequestMatchers("/actuator/**", "/api/v1/products/all", 
+                    "/api/v1/products/*/price", "/api/v1/products/search"))
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/api/v1/products/all", "/api/v1/products/*/price",


### PR DESCRIPTION
Potential fix for [https://github.com/PhumlaniDev/infinity-tech-product-service/security/code-scanning/10](https://github.com/PhumlaniDev/infinity-tech-product-service/security/code-scanning/10)

To fix the issue, CSRF protection should be enabled by removing the `http.csrf(AbstractHttpConfigurer::disable)` line. If there are specific endpoints that do not require CSRF protection (e.g., public APIs), they can be excluded from CSRF protection using Spring Security's `csrf().ignoringRequestMatchers()` method. This approach ensures that CSRF protection is enabled for all other endpoints while allowing flexibility for non-browser clients.

**Steps to fix:**
1. Remove the `http.csrf(AbstractHttpConfigurer::disable)` line.
2. If necessary, configure CSRF protection to ignore specific endpoints using `csrf().ignoringRequestMatchers()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
